### PR TITLE
Add metadata/layout.conf.

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo


### PR DESCRIPTION
Silences portage warning about missing 'masters' attribute.
